### PR TITLE
Add Permissions system to tokens for module support

### DIFF
--- a/src/badge/Badge.sol
+++ b/src/badge/Badge.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.13;
 
 import "openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
 import "solmate/src/tokens/ERC1155.sol";
 import "./storage/BadgeStorageV0.sol";
 import "../lib/renderer/IRenderer.sol";
+import "../lib/Permissions.sol";
 import "./IBadge.sol";
 
-contract Badge is IBadge, Initializable, UUPSUpgradeable, Ownable, ERC1155, BadgeStorageV0 {
+contract Badge is IBadge, Initializable, UUPSUpgradeable, Permissions, ERC1155, BadgeStorageV0 {
     function init(address _owner, address _renderer, string memory _name, string memory _symbol) external initializer {
         _transferOwnership(_owner);
         renderer = _renderer;
@@ -21,7 +21,7 @@ contract Badge is IBadge, Initializable, UUPSUpgradeable, Ownable, ERC1155, Badg
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     function uri(uint256 id) public view override returns (string memory) {
-      return IRenderer(renderer).tokenURI(id);
+        return IRenderer(renderer).tokenURI(id);
     }
 
     function updateRenderer(address _renderer) external onlyOwner {
@@ -29,11 +29,11 @@ contract Badge is IBadge, Initializable, UUPSUpgradeable, Ownable, ERC1155, Badg
         emit UpdatedRenderer(_renderer);
     }
 
-    function mintTo(address recipient, uint256 tokenId) external onlyOwner {
+    function mintTo(address recipient, uint256 tokenId) external permitted(Operation.MINT) {
         _mint(recipient, tokenId, 1, "");
     }
 
-    function burnFrom(address account, uint256 tokenId, uint256 amount) external onlyOwner {
+    function burnFrom(address account, uint256 tokenId, uint256 amount) external permitted(Operation.BURN) {
         _burn(account, tokenId, amount);
     }
 

--- a/src/lib/Permissions.sol
+++ b/src/lib/Permissions.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
+
+/// @notice Multi-role system managed by a singular owner with enums and bitmap packing
+/// @dev inspired by OZ's AccessControl
+/// TODO: add supportsInterface compatibility
+contract Permissions is Ownable {
+    enum Operation {
+        MINT,
+        BURN
+    }
+
+    event PermissionGranted(address indexed account, Operation indexed operation);
+    event PermissionRevoked(address indexed account, Operation indexed operation);
+
+    // accounts => 256 auth'd operations, each represented by their own bit
+    mapping(address => bytes32) internal permissions;
+
+    // check if sender is owner or has the permission for the operation
+    modifier permitted(Operation operation) {
+        require(owner() == msg.sender || hasPermission(msg.sender, operation), "NOT_PERMITTED");
+        _;
+    }
+
+    function hasPermission(address account, Operation operation) public view virtual returns (bool) {
+        return permissions[account] & _operationBit(operation) != 0;
+    }
+
+    function grantPermission(address account, Operation operation) external onlyOwner {
+        _grant(account, operation);
+    }
+
+    function revokePermission(address account, Operation operation) external onlyOwner {
+        _revoke(account, operation);
+    }
+
+    function _grant(address account, Operation operation) internal {
+        require(account != address(0), "ZERO_ADDRESS");
+        // bitwise OR with 1 bitshifted `operation` positions left
+        // result: `operation` index value = 1
+        permissions[account] |= _operationBit(operation);
+
+        emit PermissionGranted(account, operation);
+    }
+
+    function _revoke(address account, Operation operation) internal {
+        require(account != address(0), "ZERO_ADDRESS");
+        // bitwise AND with NOT(1 bitshifted `operation` positions left)
+        // result: `operation` index value = 0
+        permissions[account] &= ~_operationBit(operation);
+
+        emit PermissionRevoked(account, operation);
+    }
+
+    function _operationBit(Operation operation) internal pure returns (bytes32) {
+        return bytes32(1 << uint8(operation));
+    }
+}

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -6,5 +6,5 @@ interface IMembership {
 
     function updateRenderer(address _renderer) external;
     function mintTo(address recipient, uint256 tokenId) external;
-    function burnFrom(uint256 tokenId) external;
+    function burn(uint256 tokenId) external;
 }

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -5,6 +5,6 @@ interface IMembership {
     event UpdatedRenderer(address indexed renderer);
 
     function updateRenderer(address _renderer) external;
-    function mintTo(address recipient, uint256 tokenId) external;
+    function mintTo(address recipient) external;
     function burnFrom(uint256 tokenId) external;
 }

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -6,5 +6,5 @@ interface IMembership {
 
     function updateRenderer(address _renderer) external;
     function mintTo(address recipient, uint256 tokenId) external;
-    function burn(uint256 tokenId) external;
+    function burnFrom(uint256 tokenId) external;
 }

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -47,8 +47,8 @@ contract Membership is IMembership, Initializable, UUPSUpgradeable, Permissions,
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-    function mintTo(address recipient, uint256 tokenId) external permitted(Operation.MINT) {
-        _mint(recipient, tokenId);
+    function mintTo(address recipient) external permitted(Operation.MINT) {
+        _mint(recipient, counter++);
     }
 
     function burnFrom(uint256 tokenId) external permitted(Operation.BURN) {

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -48,7 +48,7 @@ contract Membership is IMembership, Initializable, UUPSUpgradeable, Permissions,
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     function mintTo(address recipient) external permitted(Operation.MINT) {
-        _mint(recipient, counter++);
+        _mint(recipient, totalSupply++);
     }
 
     function burnFrom(uint256 tokenId) external permitted(Operation.BURN) {

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -51,7 +51,7 @@ contract Membership is IMembership, Initializable, UUPSUpgradeable, Permissions,
         _mint(recipient, tokenId);
     }
 
-    function burn(uint256 tokenId) external permitted(Operation.BURN) {
+    function burnFrom(uint256 tokenId) external permitted(Operation.BURN) {
         _burn(tokenId);
     }
 }

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import "openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "solmate/src/tokens/ERC721.sol";
-import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import "../lib/renderer/IRenderer.sol";
+import "../lib/Permissions.sol";
 import "./storage/MembershipStorageV0.sol";
 import "./IMembership.sol";
 
-contract Membership is IMembership, Initializable, UUPSUpgradeable, Ownable, ERC721, MembershipStorageV0 {
+contract Membership is IMembership, Initializable, UUPSUpgradeable, Permissions, ERC721, MembershipStorageV0 {
     constructor() ERC721("", "") {}
 
     ///                                                          ///
@@ -47,11 +47,11 @@ contract Membership is IMembership, Initializable, UUPSUpgradeable, Ownable, ERC
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-    function mintTo(address recipient, uint256 tokenId) external onlyOwner {
+    function mintTo(address recipient, uint256 tokenId) external permitted(Operation.MINT) {
         _mint(recipient, tokenId);
     }
 
-    function burnFrom(uint256 tokenId) external onlyOwner {
+    function burn(uint256 tokenId) external permitted(Operation.BURN) {
         _burn(tokenId);
     }
 }

--- a/src/membership/storage/MembershipStorageV0.sol
+++ b/src/membership/storage/MembershipStorageV0.sol
@@ -5,4 +5,5 @@ pragma solidity ^0.8.13;
 // interesting that they are not in solmate/1155
 contract MembershipStorageV0 {
     address public renderer;
+    uint256 public counter;
 }

--- a/src/membership/storage/MembershipStorageV0.sol
+++ b/src/membership/storage/MembershipStorageV0.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-// name and symbol already found in solmate/721
-// interesting that they are not in solmate/1155
 contract MembershipStorageV0 {
+    // augment `tokenURI` through a Renderer contract
     address public renderer;
-    uint256 public counter;
+    // self-incrementing id for minting tokens, doubly functions as totalSupply function
+    uint256 public totalSupply;
 }

--- a/src/modules/Example.sol
+++ b/src/modules/Example.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "../membership/IMembership.sol";
+
+contract Example {
+    function example(address membership) external {
+        // 1. auth
+
+        // 2. update any local state
+
+        // 3. mint
+        IMembership(membership).mintTo(msg.sender);
+    }
+}


### PR DESCRIPTION
- add basic `Permissions` contract to support multi-operation and multi-owner permissions wrapped around `Ownable`
- also will support modules by enabling permissions for a specific operation (e.g. grant mint permission to 0xModule)
- apply to `Badge` and `Membership`