### PR TITLE
Add guard updates for identity and non-transferability constraints

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
 	branch = v4.8.3
+[submodule "lib/contracts"]
+	path = lib/contracts
+	url = https://github.com/tokenbound/contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,6 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/
-openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
+openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
+openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 solmate/=lib/solmate/
+tokenbound/=lib/contracts/

--- a/script/badge/Deploy.s.sol
+++ b/script/badge/Deploy.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Script.sol";
 import "../../src/lib/renderer/Renderer.sol";
 import "../../src/badge/Badge.sol";
-import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract Deploy is Script {
     function setUp() public {}

--- a/script/membership/Deploy.s.sol
+++ b/script/membership/Deploy.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Script.sol";
 import "../../src/lib/renderer/Renderer.sol";
 import "../../src/membership/Membership.sol";
-import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract Deploy is Script {
     function setUp() public {}

--- a/script/membership/DeployDelayed.s.sol
+++ b/script/membership/DeployDelayed.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Script.sol";
 import "../../src/lib/renderer/Renderer.sol";
 import "../../src/membership/Membership.sol";
-import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract Deploy is Script {
     function setUp() public {}
@@ -14,8 +14,13 @@ contract Deploy is Script {
         address delayed_renderer = 0x4377183d9f9376E7DA270c3d103F0250A5ec803f;
         address membershipImpl = address(new Membership());
 
-        bytes memory initData =
-            abi.encodeWithSelector(Membership(membershipImpl).initialize.selector, msg.sender, delayed_renderer, "Friends of Station", "FRIENDS");
+        bytes memory initData = abi.encodeWithSelector(
+            Membership(membershipImpl).initialize.selector,
+            msg.sender,
+            delayed_renderer,
+            "Friends of Station",
+            "FRIENDS"
+        );
         new ERC1967Proxy(membershipImpl, initData);
         vm.stopBroadcast();
     }

--- a/script/membership/DeployFactory.s.sol
+++ b/script/membership/DeployFactory.s.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 import "../../src/lib/renderer/Renderer.sol";
 import "../../src/membership/Membership.sol";
 import "../../src/membership/MembershipFactory.sol";
-import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 // DEPLOY SCRIPT (goerli)
 // forge script script/membership/DeployFactory.s.sol:Deploy --fork-url $GOERLI_RPC_URL --keystores $ETH_KEYSTORE --password $KEYSTORE_PASSWORD --sender $ETH_FROM --broadcast

--- a/src/badge/Badge.sol
+++ b/src/badge/Badge.sol
@@ -6,8 +6,8 @@ import {IBadge} from "./IBadge.sol";
 import {ITokenGuard} from "src/lib/guard/ITokenGuard.sol";
 import {IRenderer} from "../lib/renderer/IRenderer.sol";
 // contracts
-import {UUPSUpgradeable} from "openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {ERC1155Upgradeable} from "openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol";
+import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
+import {ERC1155Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import {Permissions} from "../lib/Permissions.sol";
 import {BadgeStorageV0} from "./storage/BadgeStorageV0.sol";
 

--- a/src/badge/Badge.sol
+++ b/src/badge/Badge.sol
@@ -69,15 +69,15 @@ contract Badge is IBadge, UUPSUpgradeable, ERC1155Upgradeable, Permissions, Badg
         address guard;
         // MINT
         if (from == address(0)) {
-            guard = guards[Operation.MINT];
+            guard = guardOf[Operation.MINT];
         }
         // BURN
         else if (to == address(0)) {
-            guard = guards[Operation.BURN];
+            guard = guardOf[Operation.BURN];
         }
         // TRANSFER
         else {
-            guard = guards[Operation.TRANSFER];
+            guard = guardOf[Operation.TRANSFER];
         }
 
         require(

--- a/src/badge/BadgeFactory.sol
+++ b/src/badge/BadgeFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "openzeppelin-contracts/contracts/security/Pausable.sol";
-import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
+import "openzeppelin-contracts/security/Pausable.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "./IBadge.sol";
 
 contract BadgeFactory is Ownable, Pausable {
@@ -22,11 +22,10 @@ contract BadgeFactory is Ownable, Pausable {
         whenNotPaused
         returns (address badge)
     {
-      bytes memory initData =
-      abi.encodeWithSelector(IBadge(template).init.selector, owner, renderer, name, symbol);
-      badge  = address(new ERC1967Proxy(template, initData));
+        bytes memory initData = abi.encodeWithSelector(IBadge(template).init.selector, owner, renderer, name, symbol);
+        badge = address(new ERC1967Proxy(template, initData));
 
-      emit BadgeCreated(badge);
+        emit BadgeCreated(badge);
     }
 
     function pause() external onlyOwner {

--- a/src/lib/guard/OnePerAddress.sol
+++ b/src/lib/guard/OnePerAddress.sol
@@ -5,7 +5,8 @@ import {ITokenGuard} from "./ITokenGuard.sol";
 
 // Enforces that one address can own one of a token at a time.
 // Often used for identity and reputational use cases.
-// Called after token transfer takes place.
+// Guard called after token transfer state change made through _afterTokenTransfer hook.
+// Supports all of erc20, erc721, and erc1155 standards.
 contract OnePerAddress is ITokenGuard {
     // erc20 & erc721
     function isAllowed(address, address, address to, uint256) external returns (bool) {

--- a/src/lib/guard/OnePerAddress.sol
+++ b/src/lib/guard/OnePerAddress.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ITokenGuard} from "./ITokenGuard.sol";
+
+// Enforces that one address can own one of a token at a time.
+// Often used for identity and reputational use cases.
+// Called after token transfer takes place.
+contract OnePerAddress is ITokenGuard {
+    // erc20 & erc721
+    function isAllowed(address, address, address to, uint256) external returns (bool) {
+        return ITokenBalance(msg.sender).balanceOf(to) < 2;
+    }
+
+    // erc1155
+    function isAllowed(address, address, address to, uint256[] memory ids, uint256[] memory) external returns (bool) {
+        uint256 len = ids.length;
+        for (uint256 i; i < len; i++) {
+            if (ITokenBalance(msg.sender).balanceOf(to, ids[i]) > 1) return false;
+        }
+        return true;
+    }
+}
+
+interface ITokenBalance {
+    // erc20 & erc721
+    function balanceOf(address account) external returns (uint256);
+    // erc1155
+    function balanceOf(address account, uint256 id) external returns (uint256);
+}

--- a/src/lib/renderer/DelayedRevealRenderer.sol
+++ b/src/lib/renderer/DelayedRevealRenderer.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "openzeppelin-contracts/contracts/utils/Strings.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/utils/Strings.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 import "./IDelayedRevealRenderer.sol";
 
 contract DelayedRevealRenderer is IDelayedRevealRenderer, Ownable {
@@ -28,23 +28,12 @@ contract DelayedRevealRenderer is IDelayedRevealRenderer, Ownable {
     }
 
     function tokenURI(address token, uint256 tokenId) external view returns (string memory) {
-      bool isRevealed = revealed[token];
-      string memory baseURI = baseURIs[token];
+        bool isRevealed = revealed[token];
+        string memory baseURI = baseURIs[token];
 
-      if (!isRevealed) {
-        return string(
-            abi.encodePacked(
-                baseURI,
-                "pre.json"
-            )
-        );
-      }
-       return string(
-          abi.encodePacked(
-              baseURI,
-              Strings.toString(tokenId),
-              ".json"
-          )
-      );
+        if (!isRevealed) {
+            return string(abi.encodePacked(baseURI, "pre.json"));
+        }
+        return string(abi.encodePacked(baseURI, Strings.toString(tokenId), ".json"));
     }
 }

--- a/src/lib/renderer/Renderer.sol
+++ b/src/lib/renderer/Renderer.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "openzeppelin-contracts/contracts/utils/Strings.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/utils/Strings.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 import "./IRenderer.sol";
 import {Permissions} from "src/lib/Permissions.sol";
 

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -67,15 +67,15 @@ contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissi
         address guard;
         // MINT
         if (from == address(0)) {
-            guard = guards[Operation.MINT];
+            guard = guardOf[Operation.MINT];
         }
         // BURN
         else if (to == address(0)) {
-            guard = guards[Operation.BURN];
+            guard = guardOf[Operation.BURN];
         }
         // TRANSFER
         else {
-            guard = guards[Operation.TRANSFER];
+            guard = guardOf[Operation.TRANSFER];
         }
 
         require(

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -6,8 +6,8 @@ import {IMembership} from "./IMembership.sol";
 import {ITokenGuard} from "src/lib/guard/ITokenGuard.sol";
 import {IRenderer} from "../lib/renderer/IRenderer.sol";
 // contracts
-import {UUPSUpgradeable} from "openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {ERC721Upgradeable} from "openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
+import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
+import {ERC721Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import {Permissions} from "../lib/Permissions.sol";
 import {MembershipStorageV0} from "./storage/MembershipStorageV0.sol";
 

--- a/src/membership/MembershipFactory.sol
+++ b/src/membership/MembershipFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "openzeppelin-contracts/contracts/security/Pausable.sol";
-import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
+import "openzeppelin-contracts/security/Pausable.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import "./IMembership.sol";
 
@@ -25,7 +25,7 @@ contract MembershipFactory is Ownable, Pausable {
     {
         bytes memory initData =
             abi.encodeWithSelector(IMembership(template).initialize.selector, owner, renderer, name, symbol);
-        membership  = address(new ERC1967Proxy(template, initData));
+        membership = address(new ERC1967Proxy(template, initData));
 
         emit MembershipCreated(membership);
     }

--- a/src/modules/FixedETHPurchaseModule.sol
+++ b/src/modules/FixedETHPurchaseModule.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {IMembership} from "../membership/IMembership.sol";
-import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
 
 contract FixedETHPurchaseModule is Ownable {
     mapping(address => uint256) public prices;

--- a/test/TestPaymentModule.t.sol
+++ b/test/TestPaymentModule.t.sol
@@ -51,7 +51,7 @@ contract PaymentModuleTest is Test {
 
         paymentModule.mint{value: price + fee}(membership);
 
-        assertEq(membershipContract.ownerOf(0), address(1));
+        assertEq(membershipContract.ownerOf(1), address(1));
         vm.stopPrank();
     }
 }

--- a/test/guard/OnePerAddress.t.sol
+++ b/test/guard/OnePerAddress.t.sol
@@ -7,6 +7,7 @@ import {Permissions} from "src/lib/Permissions.sol";
 import {Membership} from "src/membership/Membership.sol";
 import {MembershipFactory} from "src/membership/MembershipFactory.sol";
 import {Renderer} from "src/lib/renderer/Renderer.sol";
+import {Account as TBA} from "tokenbound/src/Account.sol";
 
 // designed to make sure the payment module itself is working properly.
 // different than TestPaymentModule which is designed to test if payment module can be added to a membership
@@ -28,10 +29,14 @@ contract OnePerAddressTest is Test {
         membershipFactory = new MembershipFactory(membershipImpl, msg.sender);
     }
 
-    function test_membershipMint(address owner, address account) public {
-        vm.assume(owner != address(0));
-        vm.assume(account != address(0));
-        vm.assume(account != address(this));
+    // create Account that supports NFT receivers to avoid fuzz errors on existing contracts in testing ops
+    function createAccount() public returns (address) {
+        return address(new TBA(address(0)));
+    }
+
+    function test_membershipMint() public {
+        address owner = createAccount();
+        address account = createAccount();
 
         address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
         vm.startPrank(owner);
@@ -48,10 +53,10 @@ contract OnePerAddressTest is Test {
         vm.stopPrank();
     }
 
-    function test_membershipTransfer(address owner, address account1, address account2) public {
-        vm.assume(owner != address(0));
-        vm.assume(account1 != address(0) && account1 != address(this));
-        vm.assume(account2 != address(0) && account2 != address(this));
+    function test_membershipTransfer() public {
+        address owner = createAccount();
+        address account1 = createAccount();
+        address account2 = createAccount();
 
         address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
         vm.startPrank(owner);

--- a/test/guard/OnePerAddress.t.sol
+++ b/test/guard/OnePerAddress.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {OnePerAddress} from "src/lib/guard/OnePerAddress.sol";
+import {Permissions} from "src/lib/Permissions.sol";
+import {Membership} from "src/membership/Membership.sol";
+import {MembershipFactory} from "src/membership/MembershipFactory.sol";
+import {Renderer} from "src/lib/renderer/Renderer.sol";
+
+// designed to make sure the payment module itself is working properly.
+// different than TestPaymentModule which is designed to test if payment module can be added to a membership
+// and work correctly with the membership.
+contract OnePerAddressTest is Test {
+    address public onePerAddress;
+    address public rendererImpl;
+    address public membershipImpl;
+    MembershipFactory public membershipFactory;
+
+    function setUp() public {
+        onePerAddress = address(new OnePerAddress());
+        rendererImpl = address(new Renderer(msg.sender, "https://tokens.station.express"));
+        setUpMembership();
+    }
+
+    function setUpMembership() public {
+        membershipImpl = address(new Membership());
+        membershipFactory = new MembershipFactory(membershipImpl, msg.sender);
+    }
+
+    function test_membership(address owner, address account) public {
+        vm.assume(owner != address(0));
+        vm.assume(account != address(0));
+
+        address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
+        vm.startPrank(owner);
+        // set guard
+        Permissions(proxy).guard(Permissions.Operation.MINT, onePerAddress);
+        // first mint, should pass
+        Membership(proxy).mintTo(account);
+        assertEq(Membership(proxy).balanceOf(account), 1);
+        // second mint, should fail
+        vm.expectRevert("NOT_ALLOWED");
+        Membership(proxy).mintTo(account);
+        // balance still 1
+        assertEq(Membership(proxy).balanceOf(account), 1);
+        vm.stopPrank();
+    }
+}

--- a/test/guard/OnePerAddress.t.sol
+++ b/test/guard/OnePerAddress.t.sol
@@ -20,17 +20,18 @@ contract OnePerAddressTest is Test {
     function setUp() public {
         onePerAddress = address(new OnePerAddress());
         rendererImpl = address(new Renderer(msg.sender, "https://tokens.station.express"));
-        setUpMembership();
+        setUp_membership();
     }
 
-    function setUpMembership() public {
+    function setUp_membership() public {
         membershipImpl = address(new Membership());
         membershipFactory = new MembershipFactory(membershipImpl, msg.sender);
     }
 
-    function test_membership(address owner, address account) public {
+    function test_membershipMint(address owner, address account) public {
         vm.assume(owner != address(0));
         vm.assume(account != address(0));
+        vm.assume(account != address(this));
 
         address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
         vm.startPrank(owner);
@@ -44,6 +45,31 @@ contract OnePerAddressTest is Test {
         Membership(proxy).mintTo(account);
         // balance still 1
         assertEq(Membership(proxy).balanceOf(account), 1);
+        vm.stopPrank();
+    }
+
+    function test_membershipTransfer(address owner, address account1, address account2) public {
+        vm.assume(owner != address(0));
+        vm.assume(account1 != address(0) && account1 != address(this));
+        vm.assume(account2 != address(0) && account2 != address(this));
+
+        address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
+        vm.startPrank(owner);
+        // set guard
+        Permissions(proxy).guard(Permissions.Operation.TRANSFER, onePerAddress);
+        // mint to two addresses, should pass
+        uint256 token1 = Membership(proxy).mintTo(account1);
+        Membership(proxy).mintTo(account2);
+        assertEq(Membership(proxy).balanceOf(account1), 1);
+        assertEq(Membership(proxy).balanceOf(account2), 1);
+        vm.stopPrank();
+        vm.startPrank(account1);
+        // transfer 1->2, should fail
+        vm.expectRevert("NOT_ALLOWED");
+        Membership(proxy).transferFrom(account1, account2, token1);
+        // balances still 1
+        assertEq(Membership(proxy).balanceOf(account1), 1);
+        assertEq(Membership(proxy).balanceOf(account2), 1);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
- Add new guard `OnePerAddress`: one address can only own one unit of token (meant mostly for NFTs)
- Refactor guard update event to make parameters indexed
- rename guard update function to the active word `guard`
- add `guardAndSetup` for atomically setting and configuring guards
- rename permissions and guards accessors to `xOf` style
- add tests for using guard on 721 & 1155 mints & transfers
- refactor `remappings.txt` for contract file paths -> sorry for the large diff!