### PR TITLE
Add batch function and setup on creation to Badge and Membership

### DIFF
--- a/script/membership/Deploy.s.sol
+++ b/script/membership/Deploy.s.sol
@@ -16,7 +16,7 @@ contract Deploy is Script {
         address membershipImpl = address(new Membership());
 
         bytes memory initData =
-            abi.encodeWithSelector(Membership(membershipImpl).initialize.selector, owner, renderer, "6551 Squad", "TBA");
+            abi.encodeWithSelector(Membership(membershipImpl).init.selector, owner, renderer, "6551 Squad", "TBA");
         new ERC1967Proxy(membershipImpl, initData);
         vm.stopBroadcast();
     }

--- a/script/membership/DeployDelayed.s.sol
+++ b/script/membership/DeployDelayed.s.sol
@@ -15,11 +15,7 @@ contract Deploy is Script {
         address membershipImpl = address(new Membership());
 
         bytes memory initData = abi.encodeWithSelector(
-            Membership(membershipImpl).initialize.selector,
-            msg.sender,
-            delayed_renderer,
-            "Friends of Station",
-            "FRIENDS"
+            Membership(membershipImpl).init.selector, msg.sender, delayed_renderer, "Friends of Station", "FRIENDS"
         );
         new ERC1967Proxy(membershipImpl, initData);
         vm.stopBroadcast();

--- a/src/badge/Badge.sol
+++ b/src/badge/Badge.sol
@@ -9,9 +9,10 @@ import {IRenderer} from "../lib/renderer/IRenderer.sol";
 import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
 import {ERC1155Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import {Permissions} from "../lib/Permissions.sol";
+import {Batch} from "../lib/Batch.sol";
 import {BadgeStorageV0} from "./storage/BadgeStorageV0.sol";
 
-contract Badge is IBadge, UUPSUpgradeable, ERC1155Upgradeable, Permissions, BadgeStorageV0 {
+contract Badge is IBadge, UUPSUpgradeable, ERC1155Upgradeable, Permissions, Batch, BadgeStorageV0 {
     function init(address _owner, address _renderer, string memory _name, string memory _symbol) external initializer {
         _transferOwnership(_owner);
         _updateRenderer(_renderer);

--- a/src/badge/Badge.sol
+++ b/src/badge/Badge.sol
@@ -13,11 +13,36 @@ import {Batch} from "../lib/Batch.sol";
 import {BadgeStorageV0} from "./storage/BadgeStorageV0.sol";
 
 contract Badge is IBadge, UUPSUpgradeable, ERC1155Upgradeable, Permissions, Batch, BadgeStorageV0 {
-    function init(address _owner, address _renderer, string memory _name, string memory _symbol) external initializer {
-        _transferOwnership(_owner);
-        _updateRenderer(_renderer);
-        name = _name;
-        symbol = _symbol;
+    /// @notice Initializes the ERC1155 token.
+    /// @param newOwner The address to transfer ownership to.
+    /// @param newRenderer The address of the renderer.
+    /// @param newName The name of the token.
+    /// @param newSymbol The symbol of the token.
+    function init(address newOwner, address newRenderer, string calldata newName, string calldata newSymbol)
+        public
+        initializer
+    {
+        _transferOwnership(newOwner);
+        _updateRenderer(newRenderer);
+        name = newName;
+        symbol = newSymbol;
+    }
+
+    /// @notice Initializes the ERC1155 token and makes other setup state changes.
+    /// @param newOwner The address to transfer ownership to.
+    /// @param newRenderer The address of the renderer.
+    /// @param newName The name of the token.
+    /// @param newSymbol The symbol of the token.
+    /// @param setupCalls The calls to make on other functions to initialize additional state.
+    function initAndSetup(
+        address newOwner,
+        address newRenderer,
+        string calldata newName,
+        string calldata newSymbol,
+        bytes[] calldata setupCalls
+    ) external {
+        init(newOwner, newRenderer, newName, newSymbol);
+        batch(false, setupCalls); // non-atomic batch, setup calls allowed to fail to not undo state changes made by init
     }
 
     function _authorizeUpgrade(address newImplementation) internal override permitted(Operation.UPGRADE) {}

--- a/src/badge/Badge.sol
+++ b/src/badge/Badge.sol
@@ -28,23 +28,6 @@ contract Badge is IBadge, UUPSUpgradeable, ERC1155Upgradeable, Permissions, Batc
         symbol = newSymbol;
     }
 
-    /// @notice Initializes the ERC1155 token and makes other setup state changes.
-    /// @param newOwner The address to transfer ownership to.
-    /// @param newRenderer The address of the renderer.
-    /// @param newName The name of the token.
-    /// @param newSymbol The symbol of the token.
-    /// @param setupCalls The calls to make on other functions to initialize additional state.
-    function initAndSetup(
-        address newOwner,
-        address newRenderer,
-        string calldata newName,
-        string calldata newSymbol,
-        bytes[] calldata setupCalls
-    ) external {
-        init(newOwner, newRenderer, newName, newSymbol);
-        batch(false, setupCalls); // non-atomic batch, setup calls allowed to fail to not undo state changes made by init
-    }
-
     function _authorizeUpgrade(address newImplementation) internal override permitted(Operation.UPGRADE) {}
 
     function uri(uint256 id) public view override returns (string memory) {

--- a/src/badge/BadgeFactory.sol
+++ b/src/badge/BadgeFactory.sol
@@ -16,7 +16,7 @@ contract BadgeFactory is Ownable, Pausable {
         _transferOwnership(_owner);
     }
 
-    /// @notice create a new badge via OZ Clones
+    /// @notice create a new Badge via via ERC1967Proxy
     function create(address owner, address renderer, string memory name, string memory symbol)
         external
         whenNotPaused
@@ -26,6 +26,21 @@ contract BadgeFactory is Ownable, Pausable {
         badge = address(new ERC1967Proxy(template, initData));
 
         emit BadgeCreated(badge);
+    }
+
+    /// @notice create a new Badge via ERC1967Proxy and setup other parameters
+    function createAndSetup(
+        address owner,
+        address renderer,
+        string memory name,
+        string memory symbol,
+        bytes[] calldata setupCalls
+    ) external whenNotPaused returns (address membership) {
+        bytes memory initData =
+            abi.encodeWithSelector(IBadge(template).initAndSetup.selector, owner, renderer, name, symbol, setupCalls);
+        membership = address(new ERC1967Proxy(template, initData));
+
+        emit BadgeCreated(membership);
     }
 
     function pause() external onlyOwner {

--- a/src/badge/BadgeFactory.sol
+++ b/src/badge/BadgeFactory.sol
@@ -38,7 +38,7 @@ contract BadgeFactory is Ownable, Pausable {
         bytes[] calldata setupCalls
     ) external whenNotPaused returns (address badge, Batch.Result[] memory setupResults) {
         badge = create(owner, renderer, name, symbol);
-        setupResults = Batch(badge).batch(false, setupCalls); // not-atomic batch call
+        setupResults = Batch(badge).batch(false, setupCalls); // non-atomic batch call
     }
 
     function pause() external onlyOwner {

--- a/src/badge/IBadge.sol
+++ b/src/badge/IBadge.sol
@@ -4,7 +4,14 @@ pragma solidity ^0.8.13;
 interface IBadge {
     event UpdatedRenderer(address indexed renderer);
 
-    function init(address _owner, address _renderer, string memory _name, string memory _symbol) external;
+    function init(address newOwner, address newRenderer, string memory newName, string memory newSymbol) external;
+    function initAndSetup(
+        address newOwner,
+        address newRenderer,
+        string memory newName,
+        string memory newSymbol,
+        bytes[] calldata setupCalls
+    ) external;
     function updateRenderer(address _renderer) external returns (bool success);
     function mintTo(address recipient, uint256 tokenId, uint256 amount) external returns (bool success);
     function burnFrom(address account, uint256 tokenId, uint256 amount) external returns (bool success);

--- a/src/badge/IBadge.sol
+++ b/src/badge/IBadge.sol
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import {Batch} from "src/lib/Batch.sol";
+
 interface IBadge {
     event UpdatedRenderer(address indexed renderer);
 
     function init(address newOwner, address newRenderer, string memory newName, string memory newSymbol) external;
-    function initAndSetup(
-        address newOwner,
-        address newRenderer,
-        string memory newName,
-        string memory newSymbol,
-        bytes[] calldata setupCalls
-    ) external;
     function updateRenderer(address _renderer) external returns (bool success);
     function mintTo(address recipient, uint256 tokenId, uint256 amount) external returns (bool success);
     function burnFrom(address account, uint256 tokenId, uint256 amount) external returns (bool success);

--- a/src/lib/Batch.sol
+++ b/src/lib/Batch.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+/// @notice Batch calling mechanism on the implementing contract
+/// @dev inspired by BoringBatchable: https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/BoringBatchable.sol
+abstract contract Batch {
+    function batch(bool atomic, bytes[] calldata calls) external payable {
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success,) = address(this).delegatecall(calls[i]);
+            require(success || !atomic, "BATCH_FAIL");
+        }
+    }
+}

--- a/src/lib/Batch.sol
+++ b/src/lib/Batch.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 /// @notice Batch calling mechanism on the implementing contract
 /// @dev inspired by BoringBatchable: https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/BoringBatchable.sol
 abstract contract Batch {
-    function batch(bool atomic, bytes[] calldata calls) external payable {
+    function batch(bool atomic, bytes[] calldata calls) public payable {
         uint256 len = calls.length;
         for (uint256 i = 0; i < len; i++) {
             (bool success,) = address(this).delegatecall(calls[i]);

--- a/src/lib/Batch.sol
+++ b/src/lib/Batch.sol
@@ -5,7 +5,8 @@ pragma solidity ^0.8.13;
 /// @dev inspired by BoringBatchable: https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/BoringBatchable.sol
 abstract contract Batch {
     function batch(bool atomic, bytes[] calldata calls) external payable {
-        for (uint256 i = 0; i < calls.length; i++) {
+        uint256 len = calls.length;
+        for (uint256 i = 0; i < len; i++) {
             (bool success,) = address(this).delegatecall(calls[i]);
             require(success || !atomic, "BATCH_FAIL");
         }

--- a/src/lib/Batch.sol
+++ b/src/lib/Batch.sol
@@ -2,13 +2,19 @@
 pragma solidity ^0.8.13;
 
 /// @notice Batch calling mechanism on the implementing contract
-/// @dev inspired by BoringBatchable: https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/BoringBatchable.sol
+/// @dev inspired by BoringBatchable and Multicall3
 abstract contract Batch {
-    function batch(bool atomic, bytes[] calldata calls) public payable {
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    function batch(bool atomic, bytes[] calldata calls) public payable returns (Result[] memory results) {
         uint256 len = calls.length;
         for (uint256 i = 0; i < len; i++) {
-            (bool success,) = address(this).delegatecall(calls[i]);
-            require(success || !atomic, "BATCH_FAIL");
+            Result memory result = results[i];
+            (result.success, result.returnData) = address(this).delegatecall(calls[i]);
+            require(result.success || !atomic, "BATCH_FAIL");
         }
     }
 }

--- a/src/lib/Permissions.sol
+++ b/src/lib/Permissions.sol
@@ -76,12 +76,12 @@ abstract contract Permissions {
     }
 
     /// @dev setup module parameters atomically with enabling/disabling permissions
-    function permitAndSetup(address account, bytes32 newPermissions, bytes calldata setupData)
+    function permitAndSetup(address account, bytes32 newPermissions, bytes calldata setupCall)
         external
         permitted(Operation.UPGRADE)
     {
         _permit(account, newPermissions);
-        _setup(account, setupData);
+        _setup(account, setupCall);
     }
 
     function _permit(address account, bytes32 newPermissions) internal {
@@ -107,12 +107,12 @@ abstract contract Permissions {
         _guard(operation, newGuard);
     }
 
-    function guardAndSetup(Operation operation, address newGuard, bytes calldata setupData)
+    function guardAndSetup(Operation operation, address newGuard, bytes calldata setupCall)
         external
         permitted(Operation.UPGRADE)
     {
         _guard(operation, newGuard);
-        _setup(newGuard, setupData);
+        _setup(newGuard, setupCall);
     }
 
     function _guard(Operation operation, address newGuard) internal {

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -4,9 +4,14 @@ pragma solidity ^0.8.13;
 interface IMembership {
     event UpdatedRenderer(address indexed renderer);
 
-    function init(address owner_, address renderer_, string memory name_, string memory symbol_)
-        external
-        returns (bool success);
+    function init(address newOwner, address newRenderer, string memory newName, string memory newSymbol) external;
+    function initAndSetup(
+        address newOwner,
+        address newRenderer,
+        string memory newName,
+        string memory newSymbol,
+        bytes[] calldata setupCalls
+    ) external;
     function updateRenderer(address _renderer) external returns (bool success);
     function mintTo(address recipient) external returns (uint256 tokenId);
     function burnFrom(uint256 tokenId) external returns (bool success);

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import {Batch} from "src/lib/Batch.sol";
+
 interface IMembership {
     event UpdatedRenderer(address indexed renderer);
 
     function init(address newOwner, address newRenderer, string memory newName, string memory newSymbol) external;
-    function initAndSetup(
-        address newOwner,
-        address newRenderer,
-        string memory newName,
-        string memory newSymbol,
-        bytes[] calldata setupCalls
-    ) external;
     function updateRenderer(address _renderer) external returns (bool success);
     function mintTo(address recipient) external returns (uint256 tokenId);
     function burnFrom(uint256 tokenId) external returns (bool success);

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 interface IMembership {
     event UpdatedRenderer(address indexed renderer);
 
-    function initialize(address owner_, address renderer_, string memory name_, string memory symbol_)
+    function init(address owner_, address renderer_, string memory name_, string memory symbol_)
         external
         returns (bool success);
     function updateRenderer(address _renderer) external returns (bool success);

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -29,23 +29,6 @@ contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissi
         __ERC721_init(newName, newSymbol);
     }
 
-    /// @notice Initializes the ERC1155 token and makes other setup state changes.
-    /// @param newOwner The address to transfer ownership to.
-    /// @param newRenderer The address of the renderer.
-    /// @param newName The name of the token.
-    /// @param newSymbol The symbol of the token.
-    /// @param setupCalls The calls to make on other functions to initialize additional state.
-    function initAndSetup(
-        address newOwner,
-        address newRenderer,
-        string calldata newName,
-        string calldata newSymbol,
-        bytes[] calldata setupCalls
-    ) external {
-        init(newOwner, newRenderer, newName, newSymbol);
-        batch(false, setupCalls); // non-atomic batch, setup calls allowed to fail to not undo state changes made by init
-    }
-
     function _authorizeUpgrade(address newImplementation) internal override permitted(Operation.UPGRADE) {}
 
     function updateRenderer(address _renderer) external permitted(Operation.RENDER) returns (bool success) {

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -15,20 +15,35 @@ import {MembershipStorageV0} from "./storage/MembershipStorageV0.sol";
 contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissions, Batch, MembershipStorageV0 {
     constructor() {}
 
-    /// @dev Initializes the ERC721 Token.
-    /// @param owner_ The address to transfer ownership to.
-    /// @param renderer_ The address of the renderer.
-    /// @param name_ The name of the token.
-    /// @param symbol_ The encoded function call
-    function init(address owner_, address renderer_, string memory name_, string memory symbol_)
+    /// @notice Initializes the ERC721 token.
+    /// @param newOwner The address to transfer ownership to.
+    /// @param newRenderer The address of the renderer.
+    /// @param newName The name of the token.
+    /// @param newSymbol The symbol of the token.
+    function init(address newOwner, address newRenderer, string calldata newName, string calldata newSymbol)
         public
         initializer
-        returns (bool success)
     {
-        _transferOwnership(owner_);
-        _updateRenderer(renderer_);
-        __ERC721_init(name_, symbol_);
-        return true;
+        _transferOwnership(newOwner);
+        _updateRenderer(newRenderer);
+        __ERC721_init(newName, newSymbol);
+    }
+
+    /// @notice Initializes the ERC1155 token and makes other setup state changes.
+    /// @param newOwner The address to transfer ownership to.
+    /// @param newRenderer The address of the renderer.
+    /// @param newName The name of the token.
+    /// @param newSymbol The symbol of the token.
+    /// @param setupCalls The calls to make on other functions to initialize additional state.
+    function initAndSetup(
+        address newOwner,
+        address newRenderer,
+        string calldata newName,
+        string calldata newSymbol,
+        bytes[] calldata setupCalls
+    ) external {
+        init(newOwner, newRenderer, newName, newSymbol);
+        batch(false, setupCalls); // non-atomic batch, setup calls allowed to fail to not undo state changes made by init
     }
 
     function _authorizeUpgrade(address newImplementation) internal override permitted(Operation.UPGRADE) {}

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -9,9 +9,10 @@ import {IRenderer} from "../lib/renderer/IRenderer.sol";
 import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
 import {ERC721Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import {Permissions} from "../lib/Permissions.sol";
+import {Batch} from "../lib/Batch.sol";
 import {MembershipStorageV0} from "./storage/MembershipStorageV0.sol";
 
-contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissions, MembershipStorageV0 {
+contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissions, Batch, MembershipStorageV0 {
     constructor() {}
 
     /// @dev Initializes the ERC721 Token.
@@ -19,7 +20,7 @@ contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissi
     /// @param renderer_ The address of the renderer.
     /// @param name_ The name of the token.
     /// @param symbol_ The encoded function call
-    function initialize(address owner_, address renderer_, string memory name_, string memory symbol_)
+    function init(address owner_, address renderer_, string memory name_, string memory symbol_)
         public
         initializer
         returns (bool success)

--- a/src/membership/MembershipFactory.sol
+++ b/src/membership/MembershipFactory.sol
@@ -40,7 +40,7 @@ contract MembershipFactory is Ownable, Pausable {
         bytes[] calldata setupCalls
     ) external whenNotPaused returns (address membership, Batch.Result[] memory setupResults) {
         membership = create(owner, renderer, name, symbol);
-        setupResults = Batch(membership).batch(false, setupCalls); // not-atomic batch call
+        setupResults = Batch(membership).batch(false, setupCalls); // non-atomic batch call
     }
 
     function pause() external onlyOwner {


### PR DESCRIPTION
- Add `Batch.sol` abstract contract to inherit `batch(atomic, calls)` function
- Add `initAndSetup` initializers to badge and membership chaining `init` and `batch`
- Add `createAndSetup` functions to badge and membership factories to use `initAndSetup`