### PR TITLE
Add PublicFreeMintModule and base FeeModule

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -4,3 +4,5 @@ openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 solmate/=lib/solmate/
 tokenbound/=lib/contracts/
+src/=src/
+test/=test/

--- a/script/membership/Deploy.s.sol
+++ b/script/membership/Deploy.s.sol
@@ -29,9 +29,8 @@ contract Deploy is Script {
         // address membershipImpl = 0xA9879cbfa6a1Fe2964F37BcCD6fcF6ea61EfcDbf; // polygon
         // address membershipImpl = address(new Membership());
 
-        bytes memory initData = abi.encodeWithSelector(
-            Membership(membershipImpl).init.selector, msg.sender, renderer, paymentCollector, name, symbol
-        );
+        bytes memory initData =
+            abi.encodeWithSelector(Membership(membershipImpl).init.selector, msg.sender, renderer, name, symbol);
         address proxy = address(new ERC1967Proxy(membershipImpl, initData));
 
         // config

--- a/script/tokens/DeployAltman.s.sol
+++ b/script/tokens/DeployAltman.s.sol
@@ -3,12 +3,11 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
 import "../../src/lib/renderer/Renderer.sol";
-import {Membership} from '../../src/membership/Membership.sol';
+import {Membership} from "../../src/membership/Membership.sol";
 import "../../src/membership/MembershipFactory.sol";
 import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "../../src/modules/FixedStablecoinPurchaseModule.sol";
-import { FakeERC20 } from "../../test/utils/FakeERC20.sol";
-
+import {FakeERC20} from "../../test/utils/FakeERC20.sol";
 
 // DEPLOY SCRIPT (goerli)
 // forge script script/tokens/DeployAltman.s.sol:Deploy --fork-url $GOERLI_RPC_URL --keystores $ETH_KEYSTORE --password $KEYSTORE_PASSWORD --sender $ETH_FROM --broadcast
@@ -25,39 +24,56 @@ contract Deploy is Script {
         // Renderer renderer = new Renderer(msg.sender, "https://members.station.express/api/v1/nftMetadata");
         Renderer renderer = Renderer(0x5e2D6BB7681ED5B309CE61e0276160EB2b3c4888);
         // Membership membershipImpl = new Membership();
-         Membership membershipImpl = Membership(0x8C78329C9545C50fB5566f4CE96AF6a521Af1A19);
+        Membership membershipImpl = Membership(0x8C78329C9545C50fB5566f4CE96AF6a521Af1A19);
         // MembershipFactory factory = new MembershipFactory(address(membershipImpl), msg.sender);
         MembershipFactory factory = MembershipFactory(0xC3d69FA0F895dAF59E6CBEaf7a8b6A4783f639e3);
         // FixedStablecoinPurchaseModule purchaseModule = new FixedStablecoinPurchaseModule(msg.sender, 0.001 ether, "USD", 2);
-        FixedStablecoinPurchaseModule purchaseModule = FixedStablecoinPurchaseModule(0xDC955e3AEfc125348777D3A12c361678b58Aa434);
+        FixedStablecoinPurchaseModule purchaseModule =
+            FixedStablecoinPurchaseModule(0xDC955e3AEfc125348777D3A12c361678b58Aa434);
 
         purchaseModule.append(address(fakeToken));
         address[] memory enabledTokens = new address[](1);
         enabledTokens[0] = address(fakeToken);
+        address paymentCollector = msg.sender;
 
-        bytes memory setupModuleData =
-            abi.encodeWithSelector(bytes4(keccak256("setup(uint256,bytes32)")), 1, purchaseModule.enabledTokensValue(enabledTokens));
+        bytes memory setupModuleData = abi.encodeWithSelector(
+            bytes4(keccak256("setup(uint256,bytes32)")), 1, purchaseModule.enabledTokensValue(enabledTokens)
+        );
 
-        bytes memory permitMintModuleData =
-            abi.encodeWithSelector(Permissions.permitAndSetup.selector, purchaseModule, permissionsValue(Permissions.Operation.MINT, address(membershipImpl)), setupModuleData);
+        bytes memory setPaymentCollectorData =
+            abi.encodeWithSelector(Membership.updatePaymentCollector.selector, paymentCollector);
 
-        bytes memory permitFrogUpgradeModuleData =
-            abi.encodeWithSelector(Permissions.permit.selector, 0x65A3870F48B5237f27f674Ec42eA1E017E111D63, permissionsValue(Permissions.Operation.UPGRADE, address(membershipImpl)));
+        bytes memory permitMintModuleData = abi.encodeWithSelector(
+            Permissions.permitAndSetup.selector,
+            purchaseModule,
+            permissionsValue(Permissions.Operation.MINT, address(membershipImpl)),
+            setupModuleData
+        );
 
-        bytes memory permitSymUpgradeModuleData =
-            abi.encodeWithSelector(Permissions.permit.selector, 0x016562aA41A8697720ce0943F003141f5dEAe006, permissionsValue(Permissions.Operation.UPGRADE, address(membershipImpl)));
+        bytes memory permitFrogUpgradeModuleData = abi.encodeWithSelector(
+            Permissions.permit.selector,
+            0x65A3870F48B5237f27f674Ec42eA1E017E111D63,
+            permissionsValue(Permissions.Operation.UPGRADE, address(membershipImpl))
+        );
 
-        bytes[] memory setupCalls = new bytes[](3);
-        setupCalls[0] = permitMintModuleData;
-        setupCalls[1] = permitFrogUpgradeModuleData;
-        setupCalls[2] = permitSymUpgradeModuleData;
-        factory.createAndSetup(msg.sender, address(renderer), msg.sender, "Altman Membership", "ALTMAN", setupCalls);
+        bytes memory permitSymUpgradeModuleData = abi.encodeWithSelector(
+            Permissions.permit.selector,
+            0x016562aA41A8697720ce0943F003141f5dEAe006,
+            permissionsValue(Permissions.Operation.UPGRADE, address(membershipImpl))
+        );
+
+        bytes[] memory setupCalls = new bytes[](4);
+        setupCalls[0] = setPaymentCollectorData;
+        setupCalls[1] = permitMintModuleData;
+        setupCalls[2] = permitFrogUpgradeModuleData;
+        setupCalls[3] = permitSymUpgradeModuleData;
+        factory.createAndSetup(msg.sender, address(renderer), "Altman Membership", "ALTMAN", setupCalls);
         vm.stopBroadcast();
     }
 
-  function permissionsValue (Permissions.Operation operation, address membershipImpl) public pure returns (bytes32) {
-    Permissions.Operation[] memory operations = new Permissions.Operation[](1);
-    operations[0] = operation;
-    return Permissions(membershipImpl).permissionsValue(operations);
-  }
+    function permissionsValue(Permissions.Operation operation, address membershipImpl) public pure returns (bytes32) {
+        Permissions.Operation[] memory operations = new Permissions.Operation[](1);
+        operations[0] = operation;
+        return Permissions(membershipImpl).permissionsValue(operations);
+    }
 }

--- a/src/lib/module/FeeModule.sol
+++ b/src/lib/module/FeeModule.sol
@@ -7,14 +7,21 @@ contract FeeModule is Ownable {
     uint256 public fee;
     uint256 public feeBalance;
 
+    event FeeUpdated(uint256 fee);
     event WithdrawFee(address indexed recipient, uint256 amount);
 
-    constructor(address newOwner) {
+    constructor(address newOwner, uint256 newFee) {
         _transferOwnership(newOwner);
+        _updateFee(newFee);
     }
 
     function updateFee(uint256 newFee) external onlyOwner {
+        _updateFee(newFee);
+    }
+
+    function _updateFee(uint256 newFee) internal {
         fee = newFee;
+        emit FeeUpdated(newFee);
     }
 
     function withdrawFee() external {

--- a/src/lib/module/FeeModule.sol
+++ b/src/lib/module/FeeModule.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+
+contract FeeModule is Ownable {
+    uint256 public fee;
+    uint256 public feeBalance;
+
+    event WithdrawFee(address indexed recipient, uint256 amount);
+
+    constructor(address newOwner) {
+        _transferOwnership(newOwner);
+    }
+
+    function updateFee(uint256 newFee) external onlyOwner {
+        fee = newFee;
+    }
+
+    function withdrawFee() external {
+        address recipient = owner();
+        uint256 balance = feeBalance;
+        feeBalance = 0;
+        payable(recipient).transfer(balance);
+        emit WithdrawFee(recipient, balance);
+    }
+
+    function _registerFee() internal returns (uint256 paidFee) {
+        paidFee = fee; // read from state once, gas opt
+        require(msg.value == paidFee, "INVALID_FEE");
+        feeBalance += paidFee;
+    }
+}

--- a/src/lib/module/FeeModule.sol
+++ b/src/lib/module/FeeModule.sol
@@ -33,7 +33,7 @@ contract FeeModule is Ownable {
     }
 
     function _registerFee() internal returns (uint256 paidFee) {
-        paidFee = fee; // read from state once, gas opt
+        paidFee = fee; // read from state once, gas optimization
         require(msg.value == paidFee, "INVALID_FEE");
         feeBalance += paidFee;
     }

--- a/src/membership/IMembership.sol
+++ b/src/membership/IMembership.sol
@@ -7,13 +7,7 @@ interface IMembership {
     event UpdatedRenderer(address indexed renderer);
     event UpdatedPaymentCollector(address indexed paymentCollector);
 
-    function init(
-        address newOwner,
-        address newRenderer,
-        address _paymentCollector,
-        string memory newName,
-        string memory newSymbol
-    ) external;
+    function init(address newOwner, address newRenderer, string memory newName, string memory newSymbol) external;
     function updateRenderer(address _renderer) external returns (bool success);
     function mintTo(address recipient) external returns (uint256 tokenId);
     function burnFrom(uint256 tokenId) external returns (bool success);

--- a/src/membership/Membership.sol
+++ b/src/membership/Membership.sol
@@ -20,16 +20,12 @@ contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissi
     /// @param newRenderer The address of the renderer.
     /// @param newName The name of the token.
     /// @param newSymbol The symbol of the token.
-    function init(
-        address newOwner,
-        address newRenderer,
-        address newPaymentCollector,
-        string calldata newName,
-        string calldata newSymbol
-    ) public initializer {
+    function init(address newOwner, address newRenderer, string calldata newName, string calldata newSymbol)
+        public
+        initializer
+    {
         _transferOwnership(newOwner);
         _updateRenderer(newRenderer);
-        _updatePaymentCollector(newPaymentCollector);
         __ERC721_init(newName, newSymbol);
     }
 
@@ -50,13 +46,9 @@ contract Membership is IMembership, UUPSUpgradeable, ERC721Upgradeable, Permissi
         permitted(Operation.UPGRADE)
         returns (bool success)
     {
-        _updatePaymentCollector(newPaymentCollector);
-        return true;
-    }
-
-    function _updatePaymentCollector(address newPaymentCollector) internal {
         paymentCollector = newPaymentCollector;
         emit UpdatedPaymentCollector(newPaymentCollector);
+        return true;
     }
 
     function tokenURI(uint256 id) public view override returns (string memory) {

--- a/src/membership/MembershipFactory.sol
+++ b/src/membership/MembershipFactory.sol
@@ -20,13 +20,13 @@ contract MembershipFactory is Ownable, Pausable {
     }
 
     /// @notice create a new Membership via ERC1967Proxy
-    function create(address owner, address renderer, address paymentCollector, string memory name, string memory symbol)
+    function create(address owner, address renderer, string memory name, string memory symbol)
         public
         whenNotPaused
         returns (address membership)
     {
         bytes memory initData =
-            abi.encodeWithSelector(IMembership(template).init.selector, owner, paymentCollector, renderer, name, symbol);
+            abi.encodeWithSelector(IMembership(template).init.selector, owner, renderer, name, symbol);
         membership = address(new ERC1967Proxy(template, initData));
 
         emit MembershipCreated(membership);
@@ -36,13 +36,12 @@ contract MembershipFactory is Ownable, Pausable {
     function createAndSetup(
         address owner,
         address renderer,
-        address paymentCollector,
         string memory name,
         string memory symbol,
         bytes[] calldata setupCalls
     ) external whenNotPaused returns (address membership, Batch.Result[] memory setupResults) {
         // set factory as owner so it can make calls to protected functions for setup
-        membership = create(address(this), paymentCollector, renderer, name, symbol);
+        membership = create(address(this), renderer, name, symbol);
         // make non-atomic batch call, using permission as owner to do anything
         setupResults = Batch(membership).batch(false, setupCalls);
         // transfer ownership to provided argument

--- a/src/modules/PublicFreeMintModule.sol
+++ b/src/modules/PublicFreeMintModule.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IMembership} from "../membership/IMembership.sol";
+import {FeeModule} from "../lib/module/FeeModule.sol";
+
+contract PublicFreeMintModule is FeeModule {
+    event Mint(address indexed collection, address indexed recipient, uint256 fee);
+
+    constructor(address newOwner) FeeModule(newOwner) {}
+
+    function mint(address collection) external payable {
+        _mint(collection, msg.sender);
+    }
+
+    function mintTo(address collection, address recipient) external payable {
+        _mint(collection, recipient);
+    }
+
+    function _mint(address collection, address recipient) internal {
+        uint256 paidFee = _registerFee(); // reverts on invalid fee
+        (uint256 tokenId) = IMembership(collection).mintTo(recipient);
+        require(tokenId > 0, "MINT_FAILED");
+        emit Purchase(collection, recipient, price, paidFee);
+    }
+}

--- a/src/modules/PublicFreeMintModule.sol
+++ b/src/modules/PublicFreeMintModule.sol
@@ -7,20 +7,20 @@ import {FeeModule} from "../lib/module/FeeModule.sol";
 contract PublicFreeMintModule is FeeModule {
     event Mint(address indexed collection, address indexed recipient, uint256 fee);
 
-    constructor(address newOwner) FeeModule(newOwner) {}
+    constructor(address newOwner, uint256 newFee) FeeModule(newOwner, newFee) {}
 
-    function mint(address collection) external payable {
-        _mint(collection, msg.sender);
+    function mint(address collection) external payable returns (uint256 tokenId) {
+        tokenId = _mint(collection, msg.sender);
     }
 
-    function mintTo(address collection, address recipient) external payable {
-        _mint(collection, recipient);
+    function mintTo(address collection, address recipient) external payable returns (uint256 tokenId) {
+        tokenId = _mint(collection, recipient);
     }
 
-    function _mint(address collection, address recipient) internal {
+    function _mint(address collection, address recipient) internal returns (uint256 tokenId) {
         uint256 paidFee = _registerFee(); // reverts on invalid fee
-        (uint256 tokenId) = IMembership(collection).mintTo(recipient);
+        (tokenId) = IMembership(collection).mintTo(recipient);
         require(tokenId > 0, "MINT_FAILED");
-        emit Purchase(collection, recipient, price, paidFee);
+        emit Mint(collection, recipient, paidFee);
     }
 }

--- a/test/TestFixedStablecoinPurchaseModule.t.sol
+++ b/test/TestFixedStablecoinPurchaseModule.t.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/lib/renderer/Renderer.sol";
-import { Membership } from "../src/membership/Membership.sol";
+import {Membership} from "../src/membership/Membership.sol";
 import "../src/membership/MembershipFactory.sol";
 import "../src/modules/FixedStablecoinPurchaseModule.sol";
-import { FakeERC20 } from './utils/FakeERC20.sol';
+import {FakeERC20} from "./utils/FakeERC20.sol";
 
 contract PaymentModuleTest is Test {
     address public owner = address(123);
@@ -34,15 +34,16 @@ contract PaymentModuleTest is Test {
         fakeUSDCImpl = address(new FakeERC20(6));
         fakeDAIImpl = address(new FakeERC20(18));
         membershipInstance =
-            MembershipFactory(membershipFactory).create(owner, paymentReciever, rendererImpl, "Friends of Station", "FRIENDS");
+            MembershipFactory(membershipFactory).create(owner, rendererImpl, "Friends of Station", "FRIENDS");
         membershipContract = Membership(membershipInstance);
 
         Permissions.Operation[] memory operations = new Permissions.Operation[](1);
         operations[0] = Permissions.Operation.MINT;
         membershipContract.permit(fixedStablecoinPurchaseModuleImpl, membershipContract.permissionsValue(operations));
+        membershipContract.updatePaymentCollector(paymentReciever);
 
-         // give account fake DAI + fake USDC
-         // 1000 USD equivalent
+        // give account fake DAI + fake USDC
+        // 1000 USD equivalent
         FakeERC20(fakeDAIImpl).mint(owner, BASE_BALANCE * 10 ** 18);
         FakeERC20(fakeDAIImpl).approve(fixedStablecoinPurchaseModuleImpl, BASE_BALANCE * 10 ** 18);
         FakeERC20(fakeUSDCImpl).mint(owner, BASE_BALANCE * 10 ** 6);
@@ -78,7 +79,7 @@ contract PaymentModuleTest is Test {
         // 1. add fakeUSDCImpl and fakeDAIImpl to payment module
         paymentModule.append(fakeUSDCImpl);
         paymentModule.append(fakeDAIImpl);
-         // 2. create address array of tokens we want enabled
+        // 2. create address array of tokens we want enabled
         address[] memory enabledTokens = new address[](2);
         enabledTokens[0] = fakeUSDCImpl;
         enabledTokens[1] = fakeDAIImpl;
@@ -124,23 +125,23 @@ contract PaymentModuleTest is Test {
     }
 
     function test_mint_revertIfNoFee(uint256 price) public {
-      // 2 decimals of precision, so price must be less than BASE_BALANCE with that many decimals
-      // since that is what the wallet has been given. Else, it will throw insufficient balance error
-      vm.assume(price < BASE_BALANCE * 10 ** 2);
-      startHoax(owner);
-      paymentModule.append(fakeUSDCImpl);
-      paymentModule.append(fakeDAIImpl);
-      address[] memory enabledTokens = new address[](2);
-      enabledTokens[0] = fakeUSDCImpl;
-      enabledTokens[1] = fakeDAIImpl;
-      paymentModule.setup(membershipInstance, price, paymentModule.enabledTokensValue(enabledTokens));
-      vm.expectRevert("MISSING_FEE");
-      paymentModule.mint(membershipInstance, fakeDAIImpl);
-      vm.stopPrank();
+        // 2 decimals of precision, so price must be less than BASE_BALANCE with that many decimals
+        // since that is what the wallet has been given. Else, it will throw insufficient balance error
+        vm.assume(price < BASE_BALANCE * 10 ** 2);
+        startHoax(owner);
+        paymentModule.append(fakeUSDCImpl);
+        paymentModule.append(fakeDAIImpl);
+        address[] memory enabledTokens = new address[](2);
+        enabledTokens[0] = fakeUSDCImpl;
+        enabledTokens[1] = fakeDAIImpl;
+        paymentModule.setup(membershipInstance, price, paymentModule.enabledTokensValue(enabledTokens));
+        vm.expectRevert("MISSING_FEE");
+        paymentModule.mint(membershipInstance, fakeDAIImpl);
+        vm.stopPrank();
     }
 
     function test_withdrawFee(uint256 price) public {
-       // 2 decimals of precision, so price must be less than BASE_BALANCE with that many decimals
+        // 2 decimals of precision, so price must be less than BASE_BALANCE with that many decimals
         // since that is what the wallet has been given. Else, it will throw insufficient balance error
         vm.assume(price < BASE_BALANCE * 10 ** 2);
         startHoax(owner);
@@ -246,7 +247,7 @@ contract PaymentModuleTest is Test {
         enabledTokens[1] = fakeDAIImpl;
         paymentModule.setup(membershipInstance, price, paymentModule.enabledTokensValue(enabledTokens));
 
-         vm.expectRevert("STABLECOIN_NOT_SUPPORTED");
+        vm.expectRevert("STABLECOIN_NOT_SUPPORTED");
         uint8 usdcKey = paymentModule.keyOf(newTokenImpl);
         vm.stopPrank();
     }

--- a/test/TestMembershipFactory.t.sol
+++ b/test/TestMembershipFactory.t.sol
@@ -3,44 +3,46 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/lib/renderer/Renderer.sol";
-import { Membership } from "../src/membership/Membership.sol";
+import {Membership} from "../src/membership/Membership.sol";
 import "../src/membership/MembershipFactory.sol";
 
 contract MembershipFactoryTest is Test {
-  address public paymentReciever = address(456);
-  address public membershipFactory;
-  address public rendererImpl;
-  address public membershipImpl;
+    address public paymentReciever = address(456);
+    address public membershipFactory;
+    address public rendererImpl;
+    address public membershipImpl;
 
-  function setUp() public {
-    rendererImpl = address(new Renderer(msg.sender, "https://tokens.station.express"));
-    membershipImpl = address(new Membership());
-    membershipFactory = address(new MembershipFactory(membershipImpl, msg.sender));
-  }
+    function setUp() public {
+        rendererImpl = address(new Renderer(msg.sender, "https://tokens.station.express"));
+        membershipImpl = address(new Membership());
+        membershipFactory = address(new MembershipFactory(membershipImpl, msg.sender));
+    }
 
-  function test_init() public {
-    address membership = MembershipFactory(membershipFactory).create(msg.sender, paymentReciever, rendererImpl, "Friends of Station", "FRIENDS");
-    Membership membershipContract = Membership(membership);
-    assertEq(membershipContract.owner(), msg.sender);
-    assertEq(membershipContract.renderer(), rendererImpl);
-    assertEq(membershipContract.name(), "Friends of Station");
-    assertEq(membershipContract.symbol(), "FRIENDS");
-  }
+    function test_init() public {
+        address membership =
+            MembershipFactory(membershipFactory).create(msg.sender, rendererImpl, "Friends of Station", "FRIENDS");
+        Membership membershipContract = Membership(membership);
+        assertEq(membershipContract.owner(), msg.sender);
+        assertEq(membershipContract.renderer(), rendererImpl);
+        assertEq(membershipContract.name(), "Friends of Station");
+        assertEq(membershipContract.symbol(), "FRIENDS");
+    }
 
-  // testing that minting multiple memberships does not overwrite state in either one of them
-  function test_multiple_memberships() public {
-    address membership = MembershipFactory(membershipFactory).create(msg.sender, paymentReciever, rendererImpl, "Friends of Station", "FRIENDS");
-    Membership membershipContract = Membership(membership);
-    address membership2 = MembershipFactory(membershipFactory).create(msg.sender, paymentReciever, rendererImpl, "Enemies of Station", "ENEMIES");
-    Membership membershipContract2 = Membership(membership2);
-    assertEq(membershipContract.owner(), msg.sender);
-    assertEq(membershipContract.renderer(), rendererImpl);
-    assertEq(membershipContract.name(), "Friends of Station");
-    assertEq(membershipContract.symbol(), "FRIENDS");
-    assertEq(membershipContract2.owner(), msg.sender);
-    assertEq(membershipContract2.renderer(), rendererImpl);
-    assertEq(membershipContract2.name(), "Enemies of Station");
-    assertEq(membershipContract2.symbol(), "ENEMIES");
-  }
-
+    // testing that minting multiple memberships does not overwrite state in either one of them
+    function test_multiple_memberships() public {
+        address membership =
+            MembershipFactory(membershipFactory).create(msg.sender, rendererImpl, "Friends of Station", "FRIENDS");
+        Membership membershipContract = Membership(membership);
+        address membership2 =
+            MembershipFactory(membershipFactory).create(msg.sender, rendererImpl, "Enemies of Station", "ENEMIES");
+        Membership membershipContract2 = Membership(membership2);
+        assertEq(membershipContract.owner(), msg.sender);
+        assertEq(membershipContract.renderer(), rendererImpl);
+        assertEq(membershipContract.name(), "Friends of Station");
+        assertEq(membershipContract.symbol(), "FRIENDS");
+        assertEq(membershipContract2.owner(), msg.sender);
+        assertEq(membershipContract2.renderer(), rendererImpl);
+        assertEq(membershipContract2.name(), "Enemies of Station");
+        assertEq(membershipContract2.symbol(), "ENEMIES");
+    }
 }

--- a/test/TestPaymentModule.t.sol
+++ b/test/TestPaymentModule.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/lib/renderer/Renderer.sol";
-import { Membership } from "../src/membership/Membership.sol";
+import {Membership} from "../src/membership/Membership.sol";
 import "../src/membership/MembershipFactory.sol";
 import "../src/modules/FixedETHPurchaseModule.sol";
 
@@ -29,7 +29,7 @@ contract PaymentModuleTest is Test {
     function test_mint_without_adding_payment_module_should_fail() public {
         startHoax(address(2));
         address membership =
-            MembershipFactory(membershipFactory).create(address(1), paymentReciever, rendererImpl, "Friends of Station", "FRIENDS");
+            MembershipFactory(membershipFactory).create(address(1), rendererImpl, "Friends of Station", "FRIENDS");
         Membership membershipContract = Membership(membership);
 
         vm.expectRevert("NOT_PERMITTED");
@@ -41,7 +41,7 @@ contract PaymentModuleTest is Test {
         vm.assume(price < 2 ** 128);
         startHoax(address(1));
         address membership =
-            MembershipFactory(membershipFactory).create(address(1), paymentReciever, rendererImpl, "Friends of Station", "FRIENDS");
+            MembershipFactory(membershipFactory).create(address(1), rendererImpl, "Friends of Station", "FRIENDS");
         Membership membershipContract = Membership(membership);
         FixedETHPurchaseModule paymentModule = FixedETHPurchaseModule(paymentModuleImpl);
         paymentModule.setup(membership, price);

--- a/test/guard/OnePerAddress.t.sol
+++ b/test/guard/OnePerAddress.t.sol
@@ -42,7 +42,7 @@ contract OnePerAddressTest is Test {
         address owner = createAccount();
         address account = createAccount();
 
-        address proxy = membershipFactory.create(owner, owner, rendererImpl, "Test", "TEST");
+        address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
         vm.startPrank(owner);
         // set guard
         Permissions(proxy).guard(Permissions.Operation.MINT, onePerAddress);
@@ -62,7 +62,7 @@ contract OnePerAddressTest is Test {
         address account1 = createAccount();
         address account2 = createAccount();
 
-        address proxy = membershipFactory.create(owner, owner, rendererImpl, "Test", "TEST");
+        address proxy = membershipFactory.create(owner, rendererImpl, "Test", "TEST");
         vm.startPrank(owner);
         // set guard
         Permissions(proxy).guard(Permissions.Operation.TRANSFER, onePerAddress);

--- a/test/lib/Helpers.sol
+++ b/test/lib/Helpers.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Account} from "./helpers/Account.sol";
+import {Permissions} from "./helpers/Permissions.sol";
+
+abstract contract Helpers is Account, Permissions {}

--- a/test/lib/SetUpMembership.sol
+++ b/test/lib/SetUpMembership.sol
@@ -22,6 +22,6 @@ abstract contract SetUpMembership is Helpers {
     }
 
     function create() public returns (Membership proxy) {
-        proxy = Membership(membershipFactory.create(owner, rendererImpl, paymentCollector, "Test", "TEST"));
+        proxy = Membership(membershipFactory.create(owner, rendererImpl, "Test", "TEST"));
     }
 }

--- a/test/lib/SetUpMembership.sol
+++ b/test/lib/SetUpMembership.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Renderer} from "src/lib/renderer/Renderer.sol";
+import {Membership} from "src/membership/Membership.sol";
+import {MembershipFactory} from "src/membership/MembershipFactory.sol";
+import {Helpers} from "test/lib/Helpers.sol";
+
+abstract contract SetUpMembership is Helpers {
+    address public owner;
+    address public paymentCollector;
+    address public rendererImpl;
+    Membership public membershipImpl;
+    MembershipFactory public membershipFactory;
+
+    function setUp() public virtual {
+        owner = createAccount();
+        paymentCollector = createAccount();
+        rendererImpl = address(new Renderer(owner, "https://members.station.express"));
+        membershipImpl = new Membership();
+        membershipFactory = new MembershipFactory(address(membershipImpl), owner);
+    }
+
+    function create() public returns (Membership proxy) {
+        proxy = Membership(membershipFactory.create(owner, rendererImpl, paymentCollector, "Test", "TEST"));
+    }
+}

--- a/test/lib/helpers/Account.sol
+++ b/test/lib/helpers/Account.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Account as TBA} from "tokenbound/src/Account.sol";
+
+abstract contract Account {
+    // create Account that supports NFT receivers to avoid fuzz errors on existing contracts in testing ops
+    function createAccount() public returns (address) {
+        return address(new TBA(address(0)));
+    }
+}

--- a/test/lib/helpers/Permissions.sol
+++ b/test/lib/helpers/Permissions.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Permissions as PermissionsSrc} from "src/lib/Permissions.sol";
+
+abstract contract Permissions {
+    // create Account that supports NFT receivers to avoid fuzz errors on existing contracts in testing ops
+    function operationPermissions(PermissionsSrc.Operation operation) public pure returns (bytes32 value) {
+        return bytes32(1 << uint8(operation));
+    }
+}

--- a/test/modules/PublicFreeMintModule.t.sol
+++ b/test/modules/PublicFreeMintModule.t.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {Renderer} from "src/lib/renderer/Renderer.sol";
+import {Membership} from "src/membership/Membership.sol";
+import {Permissions} from "src/lib/Permissions.sol";
+import {MembershipFactory} from "src/membership/MembershipFactory.sol";
+import {PublicFreeMintModule} from "src/modules/PublicFreeMintModule.sol";
+
+import {SetUpMembership} from "test/lib/SetUpMembership.sol";
+
+contract PublicFreeMintModuleTest is Test, SetUpMembership {
+    Membership public proxy;
+    PublicFreeMintModule public module;
+
+    function setUp() public override {
+        SetUpMembership.setUp(); // paymentCollector, renderer, implementation, factory
+        proxy = SetUpMembership.create();
+    }
+
+    function initModule(uint64 fee) public {
+        module = new PublicFreeMintModule(owner, fee);
+        // give module mint permission on proxy
+        vm.prank(owner);
+        proxy.permit(address(module), operationPermissions(Permissions.Operation.MINT));
+    }
+
+    function test_mint(uint64 fee, uint64 balanceOffset) public {
+        initModule(fee);
+
+        address recipient = createAccount();
+
+        uint256 initialBalance = uint256(fee) + uint256(balanceOffset); // cast to prevent overflow
+        vm.deal(recipient, initialBalance);
+
+        vm.startPrank(recipient);
+        // mint token
+        uint256 tokenId = module.mint{value: fee}(address(proxy));
+        // asserts
+        assertEq(proxy.balanceOf(recipient), 1);
+        assertEq(proxy.ownerOf(tokenId), recipient);
+        assertEq(proxy.totalSupply(), 1);
+        assertEq(recipient.balance, balanceOffset);
+    }
+
+    function test_mint_revertIf_invalidFee(uint64 fee, uint64 balanceOffset) public {
+        vm.assume(fee > 0);
+        initModule(fee);
+
+        address recipient = createAccount();
+
+        uint256 initialBalance = uint256(fee) + uint256(balanceOffset); // cast to prevent overflow
+        vm.deal(recipient, initialBalance);
+
+        vm.startPrank(recipient);
+        // mint token (reverts)
+        // note `fee - 1` msg.value
+        vm.expectRevert("INVALID_FEE");
+        module.mint{value: fee - 1}(address(proxy));
+        // asserts
+        assertEq(proxy.balanceOf(recipient), 0);
+        assertEq(proxy.totalSupply(), 0);
+        assertEq(recipient.balance, initialBalance);
+    }
+
+    function test_mintTo(uint64 fee, uint64 balanceOffset) public {
+        initModule(fee);
+
+        address payer = createAccount();
+        address recipient = createAccount();
+
+        uint256 initialBalance = uint256(fee) + uint256(balanceOffset); // cast to prevent overflow
+        vm.deal(payer, initialBalance);
+
+        vm.startPrank(payer);
+        // mint token
+        uint256 tokenId = module.mintTo{value: fee}(address(proxy), recipient);
+        // asserts
+        assertEq(proxy.balanceOf(recipient), 1);
+        assertEq(proxy.ownerOf(tokenId), recipient);
+        assertEq(proxy.totalSupply(), 1);
+        assertEq(payer.balance, balanceOffset);
+    }
+
+    function test_mintTo_revertIf_invalidFee(uint64 fee, uint64 balanceOffset) public {
+        vm.assume(fee > 0);
+        initModule(fee);
+
+        address payer = createAccount();
+        address recipient = createAccount();
+
+        uint256 initialBalance = uint256(fee) + uint256(balanceOffset); // cast to prevent overflow
+        vm.deal(payer, initialBalance);
+
+        vm.startPrank(payer);
+        // mint token (reverts)
+        // note `fee - 1` msg.value
+        vm.expectRevert("INVALID_FEE");
+        module.mintTo{value: fee - 1}(address(proxy), recipient);
+        // asserts
+        assertEq(proxy.balanceOf(recipient), 0);
+        assertEq(proxy.totalSupply(), 0);
+        assertEq(payer.balance, initialBalance);
+    }
+}


### PR DESCRIPTION
- Add `PublicFreeMintModule` which enables free mints with no minter restrictions while taking fixed mint fees
- Add abstract `FeeModule` contract for consolidating fee-taking logic for modules
- Add `PublicFreeMintModule` tests
- Add testing library utilities `Account`, `Permissions`, `SetUpMembership`