### PR TITLE
:bookmark: Added .gitattributes file to configure build release zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+lib/** export-ignore
+lib/** linguist-vendored
+test/** export-ignore


### PR DESCRIPTION
Gitattributes configuration necessary to prevent dependencies/submodules from sneaking their way into build release via source code zip & tar.gz