### PR TITLE
Enable counterfactual collection addresses in Tokenfactory using create2

### DIFF
--- a/script/token/CreateERC1155.s.sol
+++ b/script/token/CreateERC1155.s.sol
@@ -19,7 +19,10 @@ contract CreateERC1155 is ScriptUtils {
         CONFIG 
     ============*/
 
-    /// @notice LINEA: v.1.10
+    /// @notice MAINNET: v0.4.0 introduced a create2 salt for counterfactual collections & cross chain support
+    bytes32 inputSalt = bytes32(0x0);
+
+    /// @notice LINEA: v0.1.0
     address coreImpl = 0x7a391860CF812E8151d9c578ca4CF36a015ddb79; // ERC1155Rails Linea
 
     address public owner = ScriptUtils.symmetry;
@@ -28,7 +31,7 @@ contract CreateERC1155 is ScriptUtils {
 
     address public payoutAddress = ScriptUtils.turnkey;
 
-    /// @notice GOERLI: v1.0.0
+    /// @notice GOERLI: v0.0.0
     // address public mintModule = 0x8226Ff7e6F1CD020dC23901f71265D7d47a636d4; // Free mint goerli
     // address public metadataURIExtension = 0xD130547Bfcb52f66d0233F0206A6C427d89F81ED; // goerli
     // address public payoutAddressExtension = 0x52Db1fa1B82B63842513Da4482Cd41b26c1Bc307; // goerli
@@ -73,7 +76,7 @@ contract CreateERC1155 is ScriptUtils {
 
         bytes memory initData = abi.encodeWithSelector(Multicall.multicall.selector, initCalls);
 
-        TokenFactory(tokenFactory).createERC1155(payable(coreImpl), owner, name, symbol, initData);
+        TokenFactory(tokenFactory).createERC1155(payable(coreImpl), inputSalt, owner, name, symbol, initData);
 
         vm.stopBroadcast();
     }

--- a/script/token/CreateERC20.s.sol
+++ b/script/token/CreateERC20.s.sol
@@ -17,6 +17,9 @@ contract CreateERC20 is ScriptUtils {
     address public owner = 0x016562aA41A8697720ce0943F003141f5dEAe006;
     string public name = "DonkeyPoints";
     string public symbol = "DP";
+    
+    /// @notice MAINNET: v0.4.0 introduced a create2 salt for counterfactual collections & cross chain support
+    bytes32 inputSalt = bytes32(0x0);
 
     /// @notice Checkout lib/protocol-ops vX.Y.Z to automatically get addresses
     JsonManager.DeploysJson $deploys = setDeploysJsonStruct();
@@ -46,7 +49,7 @@ contract CreateERC20 is ScriptUtils {
 
         bytes memory initData = abi.encodeWithSelector(Multicall.multicall.selector, initCalls);
 
-        TokenFactory(tokenFactory).createERC20(payable(erc20CoreImpl), owner, name, symbol, initData);
+        TokenFactory(tokenFactory).createERC20(payable(erc20CoreImpl), inputSalt, owner, name, symbol, initData);
 
         vm.stopBroadcast();
     }

--- a/script/token/CreateERC721.s.sol
+++ b/script/token/CreateERC721.s.sol
@@ -23,6 +23,9 @@ contract CreateERC721 is ScriptUtils {
         CONFIG 
     ============*/
 
+    /// @notice MAINNET: v0.4.0 introduced a create2 salt for counterfactual collections & cross chain support
+    bytes32 inputSalt = bytes32(0x0);
+
     /// @notice LINEA: v.1.10
     address coreImpl = 0x3F4f3680c80DBa28ae43FbE160420d4Ad8ca50E4; // ERC721Rails Linea
 
@@ -94,7 +97,7 @@ contract CreateERC721 is ScriptUtils {
 
         bytes memory initData = abi.encodeWithSelector(Multicall.multicall.selector, initCalls);
 
-        TokenFactory(tokenFactory).createERC721(payable(coreImpl), owner, name, symbol, initData);
+        TokenFactory(tokenFactory).createERC721(payable(coreImpl), inputSalt, owner, name, symbol, initData);
 
         vm.stopBroadcast();
     }

--- a/src/factory/ITokenFactory.sol
+++ b/src/factory/ITokenFactory.sol
@@ -23,6 +23,7 @@ interface ITokenFactory {
 
     /// @dev Function to create a new ERC20 token proxy using given data
     /// @param implementation The logic implementation address to be set for the created proxy
+    /// @param inputSalt A 32-byte salt to enable consistent addresses across chains and prevent collision
     /// @param owner The owner address to be set for the new token proxy
     /// @param name The token name string
     /// @param symbol The token symbol string
@@ -30,6 +31,7 @@ interface ITokenFactory {
     /// @return token The created token proxy address
     function createERC20(
         address payable implementation,
+        bytes32 inputSalt,
         address owner,
         string memory name,
         string memory symbol,
@@ -38,6 +40,7 @@ interface ITokenFactory {
 
     /// @dev Function to create a new ERC721 token proxy using given data
     /// @param implementation The logic implementation address to be set for the created proxy
+    /// @param inputSalt A 32-byte salt to enable consistent addresses across chains and prevent collision
     /// @param owner The owner address to be set for the new token proxy
     /// @param name The token name string
     /// @param symbol The token symbol string
@@ -45,6 +48,7 @@ interface ITokenFactory {
     /// @return token The created token proxy address
     function createERC721(
         address payable implementation,
+        bytes32 inputSalt,
         address owner,
         string memory name,
         string memory symbol,
@@ -53,6 +57,7 @@ interface ITokenFactory {
 
     /// @dev Function to create a new ERC1155 token proxy using given data
     /// @param implementation The logic implementation address to be set for the created proxy
+    /// @param inputSalt A 32-byte salt to enable consistent addresses across chains and prevent collision
     /// @param owner The owner address to be set for the new token proxy
     /// @param name The token name string
     /// @param symbol The token symbol string
@@ -60,6 +65,7 @@ interface ITokenFactory {
     /// @return token The created token proxy address
     function createERC1155(
         address payable implementation,
+        bytes32 inputSalt,
         address owner,
         string memory name,
         string memory symbol,

--- a/src/factory/TokenFactory.sol
+++ b/src/factory/TokenFactory.sol
@@ -42,6 +42,7 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     /// @inheritdoc ITokenFactory
     function createERC20(
         address payable implementation,
+        bytes32 inputSalt,
         address owner,
         string memory name,
         string memory symbol,
@@ -49,14 +50,17 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     ) public returns (address payable token) {
         _checkIsApprovedImplementation(implementation, TokenFactoryStorage.TokenStandard.ERC20);
 
-        token = payable(address(new ERC1967Proxy(implementation, bytes(""))));
+        bytes32 deploymentSalt = keccak256(inputSalt, owner, name, symbol, initData);
+        token = payable(address(new ERC1967Proxy{salt: deploymentSalt}(implementation, bytes(""))));
         emit ERC20Created(token);
+        
         IERC20Rails(token).initialize(owner, name, symbol, initData);
     }
 
     /// @inheritdoc ITokenFactory
     function createERC721(
         address payable implementation,
+        bytes32 inputSalt,
         address owner,
         string memory name,
         string memory symbol,
@@ -64,14 +68,17 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     ) public returns (address payable token) {
         _checkIsApprovedImplementation(implementation, TokenFactoryStorage.TokenStandard.ERC721);
 
-        token = payable(address(new ERC1967Proxy(implementation, bytes(""))));
+        bytes32 deploymentSalt = keccak256(inputSalt, owner, name, symbol, initData);
+        token = payable(address(new ERC1967Proxy{salt: deploymentSalt}(implementation, bytes(""))));
         emit ERC721Created(token);
+
         IERC721Rails(token).initialize(owner, name, symbol, initData);
     }
 
     /// @inheritdoc ITokenFactory
     function createERC1155(
         address payable implementation,
+        bytes32 inputSalt,
         address owner,
         string memory name,
         string memory symbol,
@@ -79,8 +86,10 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     ) public returns (address payable token) {
         _checkIsApprovedImplementation(implementation, TokenFactoryStorage.TokenStandard.ERC1155);
 
-        token = payable(address(new ERC1967Proxy(implementation, bytes(""))));
+        bytes32 deploymentSalt = keccak256(inputSalt, owner, name, symbol, initData);
+        token = payable(address(new ERC1967Proxy{salt: deploymentSalt}(implementation, bytes(""))));
         emit ERC1155Created(token);
+
         IERC1155Rails(token).initialize(owner, name, symbol, initData);
     }
 

--- a/src/factory/TokenFactory.sol
+++ b/src/factory/TokenFactory.sol
@@ -50,10 +50,10 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     ) public returns (address payable token) {
         _checkIsApprovedImplementation(implementation, TokenFactoryStorage.TokenStandard.ERC20);
 
-        bytes32 deploymentSalt = keccak256(inputSalt, owner, name, symbol, initData);
+        bytes32 deploymentSalt = keccak256(abi.encodePacked(inputSalt, owner, name, symbol, initData));
         token = payable(address(new ERC1967Proxy{salt: deploymentSalt}(implementation, bytes(""))));
         emit ERC20Created(token);
-        
+
         IERC20Rails(token).initialize(owner, name, symbol, initData);
     }
 
@@ -68,7 +68,7 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     ) public returns (address payable token) {
         _checkIsApprovedImplementation(implementation, TokenFactoryStorage.TokenStandard.ERC721);
 
-        bytes32 deploymentSalt = keccak256(inputSalt, owner, name, symbol, initData);
+        bytes32 deploymentSalt = keccak256(abi.encodePacked(inputSalt, owner, name, symbol, initData));
         token = payable(address(new ERC1967Proxy{salt: deploymentSalt}(implementation, bytes(""))));
         emit ERC721Created(token);
 
@@ -86,7 +86,7 @@ contract TokenFactory is Initializable, Ownable, UUPSUpgradeable, ITokenFactory 
     ) public returns (address payable token) {
         _checkIsApprovedImplementation(implementation, TokenFactoryStorage.TokenStandard.ERC1155);
 
-        bytes32 deploymentSalt = keccak256(inputSalt, owner, name, symbol, initData);
+        bytes32 deploymentSalt = keccak256(abi.encodePacked(inputSalt, owner, name, symbol, initData));
         token = payable(address(new ERC1967Proxy{salt: deploymentSalt}(implementation, bytes(""))));
         emit ERC1155Created(token);
 

--- a/test/accountGroup/InitializeAccountController.t.sol
+++ b/test/accountGroup/InitializeAccountController.t.sol
@@ -38,12 +38,14 @@ contract InitializeAccountControllerTest is Test, Account {
     PermissionGatedInitializer permissionGatedInitializer;
     InitializeAccountController initializeAccountController;
 
+    bytes32 inputSalt;
     address owner;
     address entryPointAddress;
     bytes32 bytecodeSalt;
     bytes initData;
 
     function setUp() public {
+        inputSalt = bytes32(0x0);
         owner = createAccount();
         entryPointAddress = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
 
@@ -55,7 +57,7 @@ contract InitializeAccountControllerTest is Test, Account {
         erc721RailsImpl = new ERC721Rails();
         tokenFactoryProxy.initialize(owner, address(0x0), address(erc721RailsImpl), address(0x0)); // erc20, erc1155 impls not needed
 
-        erc721Rails = ERC721Rails(tokenFactoryProxy.createERC721(payable(address(erc721RailsImpl)), owner, "test", "tst", ''));
+        erc721Rails = ERC721Rails(tokenFactoryProxy.createERC721(payable(address(erc721RailsImpl)), inputSalt, owner, "test", "tst", ''));
         user = new ERC721Holder();
         vm.prank(owner);
         erc721Rails.mintTo(address(user), 1);

--- a/test/accountGroup/MintCreateInitializeController.t.sol
+++ b/test/accountGroup/MintCreateInitializeController.t.sol
@@ -39,6 +39,7 @@ contract MintCreateInitializeControllerTest is Test, Account {
     MintCreateInitializeController mintCreateInitializeController;
     ERC721AccountRails erc721AccountRails;
 
+    bytes32 inputSalt;
     address owner;
     address entryPointAddress;
     address turnkey;
@@ -48,6 +49,7 @@ contract MintCreateInitializeControllerTest is Test, Account {
     MintCreateInitializeController.MintParams mintParams;
 
     function setUp() public {
+        inputSalt = bytes32(0x0);
         owner = createAccount();
         turnkey = createAccount();
         entryPointAddress = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
@@ -61,7 +63,7 @@ contract MintCreateInitializeControllerTest is Test, Account {
         erc721RailsImpl = new ERC721Rails();
         tokenFactoryProxy.initialize(owner, address(0x0), address(erc721RailsImpl), address(0x0)); // erc20 and erc1155 implementations not needed for testing
 
-        erc721Rails = ERC721Rails(tokenFactoryProxy.createERC721(payable(address(erc721RailsImpl)), owner, "test", "tst", ''));
+        erc721Rails = ERC721Rails(tokenFactoryProxy.createERC721(payable(address(erc721RailsImpl)), inputSalt, owner, "test", "tst", ''));
         
         user = new ERC721Holder();
 

--- a/test/factory/TokenFactory.t.sol
+++ b/test/factory/TokenFactory.t.sol
@@ -23,6 +23,7 @@ contract TokenFactoryTest is Test, IERC1967 {
     TokenFactory public tokenFactoryImpl;
     TokenFactory public tokenFactoryProxy; // ERC1967 proxy wrapped in TokenFactory for convenience
 
+    bytes32 inputSalt;
     address owner;
     string public name;
     string public symbol;
@@ -39,6 +40,7 @@ contract TokenFactoryTest is Test, IERC1967 {
         // deploy badge implementation
         erc1155RailsImpl = new ERC1155Rails();
 
+        inputSalt = bytes32(0x0);
         // configure testing initData for all Rails contracts
         owner = address(0xbeefEbabe);
         name = "Station";
@@ -167,7 +169,7 @@ contract TokenFactoryTest is Test, IERC1967 {
 
         address oldMembership = address(erc721RailsProxy);
         ERC721Rails newMembership = ERC721Rails(
-            payable(tokenFactoryProxy.createERC721(payable(address(erc721RailsImpl)), newOwner, newName, newSymbol, ""))
+            payable(tokenFactoryProxy.createERC721(payable(address(erc721RailsImpl)), inputSalt, newOwner, newName, newSymbol, ""))
         );
         assertFalse(oldMembership == address(newMembership));
         assertEq(newMembership.owner(), newOwner);
@@ -182,7 +184,7 @@ contract TokenFactoryTest is Test, IERC1967 {
         address oldPoints = address(erc20RailsProxy);
 
         ERC20Rails newPoints = ERC20Rails(
-            payable(tokenFactoryProxy.createERC20(payable(address(erc20RailsImpl)), newOwner, newName, newSymbol, ""))
+            payable(tokenFactoryProxy.createERC20(payable(address(erc20RailsImpl)), inputSalt, newOwner, newName, newSymbol, ""))
         );
         assertFalse(oldPoints == address(newPoints));
         assertEq(newPoints.owner(), newOwner);
@@ -197,7 +199,7 @@ contract TokenFactoryTest is Test, IERC1967 {
         address oldBadges = address(erc1155RailsProxy);
         ERC1155Rails newBadges = ERC1155Rails(
             payable(
-                tokenFactoryProxy.createERC1155(payable(address(erc1155RailsImpl)), newOwner, newName, newSymbol, "")
+                tokenFactoryProxy.createERC1155(payable(address(erc1155RailsImpl)), inputSalt, newOwner, newName, newSymbol, "")
             )
         );
         assertFalse(oldBadges == address(newBadges));

--- a/test/lib/SetUpMembership.sol
+++ b/test/lib/SetUpMembership.sol
@@ -15,6 +15,7 @@ import {Helpers} from "test/lib/Helpers.sol";
 abstract contract SetUpMembership is Helpers {
     address public owner;
     address public payoutAddress;
+    bytes32 public inputSalt = bytes32(0);
     ERC721Rails public membershipImpl;
     TokenFactory public membershipFactoryImpl;
     TokenFactory public membershipFactory;
@@ -53,7 +54,7 @@ abstract contract SetUpMembership is Helpers {
         bytes memory initData = abi.encodeWithSelector(Multicall.multicall.selector, calls);
 
         proxy = ERC721Rails(
-            payable(membershipFactory.createERC721(payable(address(membershipImpl)), owner, "Test", "TEST", initData))
+            payable(membershipFactory.createERC721(payable(address(membershipImpl)), inputSalt, owner, "Test", "TEST", initData))
         );
     }
 }


### PR DESCRIPTION
- New `bytes32 inputSalt` parameter added to `TokenFactory::createERCxxx()`
- Derive `bytes32 deploymentSalt` from inputSalt, owner, name, symbol, and initData parameters to assure create2 collision resistance between collections
- Make `deploymentSalt` intuitive and easy to recreate offchain by using `abi.encodePacked()` rather than `abi.encode()` which would insert an extra word declaring encoded byte array length 
- Bring changes through tests and script files